### PR TITLE
Adding support for generic default types

### DIFF
--- a/json-generator/src/main/java/io/apptik/json/generator/generators/ArrayGenerator.java
+++ b/json-generator/src/main/java/io/apptik/json/generator/generators/ArrayGenerator.java
@@ -61,7 +61,9 @@ public class ArrayGenerator extends JsonGenerator {
         if (maxItems == null) {
             maxItems = 500;
         }
-        maxItems = minItems + rnd.nextInt(maxItems-minItems);
+        if(maxItems > 1) {
+            maxItems = minItems + rnd.nextInt(maxItems - minItems);
+        }
 
 
         //meant for JSON generator after all, not OutOfMemory generator :)

--- a/json-generator/src/main/java/io/apptik/json/generator/generators/BooleanGenerator.java
+++ b/json-generator/src/main/java/io/apptik/json/generator/generators/BooleanGenerator.java
@@ -18,9 +18,13 @@ package io.apptik.json.generator.generators;
 
 import io.apptik.json.JsonBoolean;
 import io.apptik.json.JsonElement;
+import io.apptik.json.JsonNumber;
+import io.apptik.json.JsonString;
 import io.apptik.json.generator.JsonGeneratorConfig;
 import io.apptik.json.generator.JsonGenerator;
 import io.apptik.json.schema.Schema;
+
+import java.util.Random;
 
 public class BooleanGenerator extends JsonGenerator {
 
@@ -34,6 +38,38 @@ public class BooleanGenerator extends JsonGenerator {
 
     @Override
     public JsonElement generate() {
-        return new JsonBoolean(rnd.nextBoolean());
+        String defaultValue = schema.getDefault();
+
+        //Check for generic default types
+        if (schema.getDefaultBoolean() != null) {
+            return new JsonBoolean(schema.getDefaultBoolean());
+        }
+        if (schema.getConstBoolean() != null) {
+            return new JsonBoolean(schema.getConstBoolean());
+        }
+        if (schema.getExamples() != null && schema.getExamples().length() > 0) {
+            return checkIfDefaultIsABoolean(schema.getExamples().get(new Random().nextInt(schema.getExamples().length())).toString());
+        }
+        if (schema.getEnum() != null && schema.getEnum().length() > 0) {
+            return checkIfDefaultIsABoolean(schema.getEnum().get(new Random().nextInt(schema.getEnum().length() -1)).toString());
+        }
+        
+        if (defaultValue != null && !defaultValue.isEmpty()) {
+            if(!defaultValue.equalsIgnoreCase("true") && !defaultValue.equalsIgnoreCase("false")) {
+                throw new RuntimeException("Default value: " + defaultValue + " of key: " + propertyName + ", is not a boolean type");
+            } else {
+                return (new JsonBoolean(Boolean.parseBoolean(defaultValue)));
+            }
+        } else {
+            return new JsonBoolean(rnd.nextBoolean());
+        }
+    }
+
+    private JsonBoolean checkIfDefaultIsABoolean(String defaultValue) {
+        if(!defaultValue.equalsIgnoreCase("true") && !defaultValue.equalsIgnoreCase("false")) {
+            throw new RuntimeException("Default value: " + defaultValue + " of key: " + propertyName + ", is not a boolean type");
+        } else {
+            return (new JsonBoolean(Boolean.parseBoolean(defaultValue)));
+        }
     }
 }

--- a/json-generator/src/main/java/io/apptik/json/generator/generators/IntegerGenerator.java
+++ b/json-generator/src/main/java/io/apptik/json/generator/generators/IntegerGenerator.java
@@ -22,6 +22,8 @@ import io.apptik.json.generator.JsonGeneratorConfig;
 import io.apptik.json.generator.JsonGenerator;
 import io.apptik.json.schema.Schema;
 
+import java.util.Random;
+
 public class IntegerGenerator extends JsonGenerator {
     public IntegerGenerator(Schema schema, JsonGeneratorConfig configuration) {
         super(schema, configuration);
@@ -35,6 +37,21 @@ public class IntegerGenerator extends JsonGenerator {
     public JsonElement generate() {
         int minValue = 0;
         int maxValue = Integer.MAX_VALUE;
+
+        //Check for generic default types
+        if (schema.getDefaultInt() != null) {
+            return new JsonNumber(schema.getDefaultInt());
+        }
+        if (schema.getConstInt() != null) {
+            return new JsonNumber(schema.getConstInt());
+        }
+        if (schema.getExamples() != null && schema.getExamples().length() > 0) {
+            return checkIfDefaultIsAInteger(schema.getExamples().get(new Random().nextInt(schema.getExamples().length())).toString());
+        }
+        if (schema.getEnum() != null && schema.getEnum().length() > 0) {
+            return checkIfDefaultIsAInteger(schema.getEnum().get(new Random().nextInt(schema.getEnum().length() -1)).toString());
+        }
+        
         if(configuration!=null) {
             if (configuration.globalIntegerMin!=null) minValue = configuration.globalIntegerMin;
             if (configuration.globalIntegerMax!=null) maxValue = configuration.globalIntegerMax;
@@ -46,5 +63,13 @@ public class IntegerGenerator extends JsonGenerator {
         }
 
         return new JsonNumber(minValue + rnd.nextInt(maxValue-minValue));
+    }
+
+    private JsonNumber checkIfDefaultIsAInteger(String defaultValue) {
+        try {
+            return new JsonNumber(Integer.parseInt(defaultValue));
+        } catch (NumberFormatException ex) {
+            throw new RuntimeException("Default value: " + defaultValue + " of key: " + propertyName + ", is not a integer type");
+        }
     }
 }

--- a/json-generator/src/main/java/io/apptik/json/generator/generators/NumberGenerator.java
+++ b/json-generator/src/main/java/io/apptik/json/generator/generators/NumberGenerator.java
@@ -18,9 +18,12 @@ package io.apptik.json.generator.generators;
 
 import io.apptik.json.JsonElement;
 import io.apptik.json.JsonNumber;
+import io.apptik.json.JsonString;
 import io.apptik.json.generator.JsonGenerator;
 import io.apptik.json.generator.JsonGeneratorConfig;
 import io.apptik.json.schema.Schema;
+
+import java.util.Random;
 
 public class NumberGenerator extends JsonGenerator {
     public NumberGenerator(Schema schema, JsonGeneratorConfig configuration) {
@@ -36,6 +39,22 @@ public class NumberGenerator extends JsonGenerator {
 
         int minValue = 0;
         int maxValue = Integer.MAX_VALUE;
+        String defaultValue = schema.getDefault();
+
+        //Check for generic default types
+        if (schema.getDefaultNumber() != null) {
+            return new JsonNumber(schema.getDefaultNumber());
+        }
+        if (schema.getConstNumber() != null) {
+            return new JsonNumber(schema.getConstNumber());
+        }
+        if (schema.getExamples() != null && schema.getExamples().length() > 0) {
+            return checkIfDefaultIsANumber(schema.getExamples().get(new Random().nextInt(schema.getExamples().length())).toString());
+        }
+        if (schema.getEnum() != null && schema.getEnum().length() > 0) {
+            return checkIfDefaultIsANumber(schema.getEnum().get(new Random().nextInt(schema.getEnum().length() -1)).toString());
+        }
+
         if(configuration!=null) {
             if (configuration.globalNumberMin!=null) minValue = configuration.globalNumberMin;
             if (configuration.globalNumberMax!=null) maxValue = configuration.globalNumberMax;
@@ -47,5 +66,13 @@ public class NumberGenerator extends JsonGenerator {
         }
 
         return new JsonNumber(minValue + rnd.nextInt(maxValue-minValue) + Math.abs(rnd.nextDouble()));
+    }
+
+    private JsonNumber checkIfDefaultIsANumber(String defaultValue) {
+        try {
+            return new JsonNumber(Double.parseDouble(defaultValue));
+        } catch (NumberFormatException ex) {
+            throw new RuntimeException("Default value: " + defaultValue + " of key: " + propertyName + ", is not a number type");
+        }
     }
 }

--- a/json-generator/src/main/java/io/apptik/json/generator/generators/StringGenerator.java
+++ b/json-generator/src/main/java/io/apptik/json/generator/generators/StringGenerator.java
@@ -27,6 +27,7 @@ import org.hamcrest.Matcher;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import java.util.Random;
 
 import static io.apptik.json.generator.matcher.FormatMatchers.*;
 
@@ -77,13 +78,27 @@ public class StringGenerator extends JsonGenerator {
                 }
             }
         }
+
+        //Check for generic default types
+        if (schema.getDefault() != null && !schema.getDefault().isEmpty()) {
+            return new JsonString(schema.getDefault());
+        }
+        if (schema.getConst() != null && !schema.getConst().isEmpty()) {
+            return new JsonString(schema.getConst());
+        }
+        if (schema.getExamples() != null && schema.getExamples().length() > 0) {
+            return new JsonString(schema.getExamples().get(new Random().nextInt(schema.getExamples().length())).toString());
+        }
+        if (schema.getEnum() != null && schema.getEnum().length() > 0) {
+            return new JsonString(schema.getEnum().get(new Random().nextInt(schema.getEnum().length() -1)).toString());
+        }
+
         if(configuration!=null) {
             if (configuration.globalStringLengthMin!=null) minChars = configuration.globalStringLengthMin;
             if (configuration.globalStringLengthMax!=null) maxChars = configuration.globalStringLengthMax;
             if (propertyName != null ) {
                 if (configuration.stringLengthMin.get(propertyName)!=null) minChars = configuration.stringLengthMin.get(propertyName);
                 if (configuration.stringLengthMax.get(propertyName)!=null) maxChars = configuration.stringLengthMax.get(propertyName);
-
                 if (configuration.stringPredefinedValues.get(propertyName) != null) {
                     return new JsonString(configuration.stringPredefinedValues.get(propertyName).get(rnd.nextInt(configuration.stringPredefinedValues.get(propertyName).size())));
                 }
@@ -92,8 +107,9 @@ public class StringGenerator extends JsonGenerator {
         }
 
         String res = "";
-        int cnt = minChars + rnd.nextInt(maxChars-minChars);
-        for(int i=0;i<cnt;i++) res += (rnd.nextBoolean())? (char)(65 + rnd.nextInt(25)):(char)(97 + rnd.nextInt(25));
+        int cnt = minChars + rnd.nextInt(maxChars - minChars);
+        for (int i = 0; i < cnt; i++)
+            res += (rnd.nextBoolean()) ? (char) (65 + rnd.nextInt(25)) : (char) (97 + rnd.nextInt(25));
         return new JsonString(res);
     }
 }

--- a/json-generator/src/test/java/io/apptik/json/generator/JsonGenerationTest.java
+++ b/json-generator/src/test/java/io/apptik/json/generator/JsonGenerationTest.java
@@ -45,7 +45,7 @@ public class JsonGenerationTest {
                         "\"type\" : \"object\"," +
                         "\"properties\" : {" +
                         "\"one\" : {\"type\" : \"number\"  } ," +
-                        "\"two\" : {\"type\" : \"string\" }," +
+                        "\"two\" : {\"type\" : \"string\"  }," +
                         "\"three\" : " + "{" +
                         "\"type\" : \"object\"," +
                         "\"properties\" : {" +
@@ -76,7 +76,102 @@ public class JsonGenerationTest {
         System.out.println(job.toString());
 
         assertEquals(8, job.length());
+    }
 
+    @Test
+    public void testDefaults() throws Exception {
+        SchemaV4 defaultsSchema = new SchemaV4().wrap(JsonElement.readFrom(
+                "{\n" +
+                        "\"type\" : \"object\"," +
+                        "\"properties\" : {" +
+                            "\"integerDefault\" : {\"type\" : \"integer\", \"default\": 1  } ," +
+                            "\"integerConst\" : {\"type\" : \"integer\", \"const\": 2  }," +
+                            "\"integerEnum\" : {\"type\" : \"integer\", \"enum\": [ 3, 4]  }," +
+                            "\"integerExamples\" : {\"type\" : \"integer\", \"examples\": [ 5, 6]  }," +
+                            "\"numberDefault\" : {\"type\" : \"number\", \"default\": 25.1  } ," +
+                            "\"numberConst\" : {\"type\" : \"number\", \"const\": 25.2  }," +
+                            "\"numberEnum\" : {\"type\" : \"number\", \"enum\": [ 25.3, 25.4 ]  }," +
+                            "\"numberExamples\" : {\"type\" : \"number\", \"examples\": [ 25.5, 25.6]  }," +
+                            "\"stringDefault\" : {\"type\" : \"string\", \"default\": \"someDefault\"  }," +
+                            "\"stringConst\" : {\"type\" : \"string\", \"const\": \"someConst\"  }," +
+                            "\"stringEnum\" : {\"type\" : \"string\", \"enum\": [\"someEnum\", \"someEnum2\"]  }," +
+                            "\"stringExamples\" : {\"type\" : \"string\", \"examples\": [\"someExample\", \"someExample2\"]  }," +
+                            "\"booleanDefault\" : {\"type\" : \"boolean\", \"default\": true  }," +
+                            "\"booleanConst\" : {\"type\" : \"boolean\", \"const\": false  }," +
+                            "\"booleanEnum\" : {\"type\" : \"boolean\", \"enum\": [ true, true]  }," +
+                            "\"booleanExamples\" : {\"type\" : \"boolean\", \"examples\": [ false, false]  }," +
+                            "\"arrayWithDefaults\" : {\"type\" : \"array\"," +
+                                " \"items\" : { \"type\" : \"object\", " +
+                                    "\"properties\" : {" +
+                                        "\"integerDefault\" : {\"type\" : \"integer\", \"default\": 1  } ," +
+                                        "\"integerConst\" : {\"type\" : \"integer\", \"const\": 2  }," +
+                                        "\"integerEnum\" : {\"type\" : \"integer\", \"enum\": [ 3, 4]  }," +
+                                        "\"integerExamples\" : {\"type\" : \"integer\", \"examples\": [ 5, 6]  }," +
+                                        "\"numberDefault\" : {\"type\" : \"number\", \"default\": 25.1  } ," +
+                                        "\"numberConst\" : {\"type\" : \"number\", \"const\": 25.2  }," +
+                                        "\"numberEnum\" : {\"type\" : \"number\", \"enum\": [ 25.3, 25.4 ]  }," +
+                                        "\"numberExamples\" : {\"type\" : \"number\", \"examples\": [ 25.5, 25.6]  }," +
+                                        "\"stringDefault\" : {\"type\" : \"string\", \"default\": \"someDefault\"  }," +
+                                        "\"stringConst\" : {\"type\" : \"string\", \"const\": \"someConst\"  }," +
+                                        "\"stringEnum\" : {\"type\" : \"string\", \"enum\": [\"someEnum\", \"someEnum2\"]  }," +
+                                        "\"stringExamples\" : {\"type\" : \"string\", \"examples\": [\"someExample\", \"someExample2\"]  }," +
+                                        "\"booleanDefault\" : {\"type\" : \"boolean\", \"default\": true  }," +
+                                        "\"booleanConst\" : {\"type\" : \"boolean\", \"const\": false  }," +
+                                        "\"booleanEnum\" : {\"type\" : \"boolean\", \"enum\": [ true, true]  }," +
+                                        "\"booleanExamples\" : {\"type\" : \"boolean\", \"examples\": [ false, false]  }" +
+                                    "}" +
+                                "}" +
+                            "}" +
+                        "}" +
+                    "}").asJsonObject());
+
+        JsonObject job = new JsonGenerator(defaultsSchema, new JsonGeneratorConfig()).generate().asJsonObject();
+        System.out.println("Output is: " + job.toString());
+        assertEquals("someDefault", job.getString("stringDefault"));
+        assertEquals("someConst", job.getString("stringConst"));
+        assertTrue(job.getString("stringEnum").contains("someEnum") || job.getString("stringEnum").contains("someEnum2"));
+        assertTrue(job.getString("stringExamples").contains("someExample") || job.getString("stringExamples").contains("someExample2"));
+
+        assertTrue(1 == job.getInt("integerDefault"));
+        assertTrue(2 == job.getInt("integerConst"));
+        assertTrue(job.getInt("integerEnum") == 3|| job.getInt("integerEnum") == 4);
+        assertTrue(job.getInt("integerExamples") == 5 || job.getInt("integerExamples") == 6);
+
+        assertEquals(25.1, job.getDouble("numberDefault"));
+        assertEquals(25.2, job.getDouble("numberConst"));
+        assertTrue(job.getDouble("numberEnum") == 25.3|| job.getDouble("numberEnum") == 25.4);
+        assertTrue(job.getDouble("numberExamples") == 25.5 || job.getDouble("numberExamples") == 25.6);
+
+        assertTrue(true == job.getBoolean("booleanDefault"));
+        assertTrue(false == job.getBoolean("booleanConst"));
+        assertTrue(job.getBoolean("booleanEnum") == true);
+        assertTrue(job.getBoolean("booleanExamples") == false);
+
+        assertEquals("someDefault", job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getString("stringDefault"));
+        assertEquals("someConst", job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getString("stringConst"));
+        assertTrue(job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getString("stringEnum").contains("someEnum")
+                || job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getString("stringEnum").contains("someEnum2"));
+        assertTrue(job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getString("stringExamples").contains("someExample")
+                || job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getString("stringExamples").contains("someExample2"));
+
+        assertTrue(1 == job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getInt("integerDefault"));
+        assertTrue(2 == job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getInt("integerConst"));
+        assertTrue(job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getInt("integerEnum") == 3
+                || job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getInt("integerEnum") == 4);
+        assertTrue(job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getInt("integerExamples") == 5
+                || job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getInt("integerExamples") == 6);
+
+        assertEquals(25.1, job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getDouble("numberDefault"));
+        assertEquals(25.2, job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getDouble("numberConst"));
+        assertTrue(job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getDouble("numberEnum") == 25.3||
+                job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getDouble("numberEnum") == 25.4);
+        assertTrue(job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getDouble("numberExamples") == 25.5 ||
+                job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getDouble("numberExamples") == 25.6);
+
+        assertTrue(true == job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getBoolean("booleanDefault"));
+        assertTrue(false == job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getBoolean("booleanConst"));
+        assertTrue(job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getBoolean("booleanEnum") == true);
+        assertTrue(job.getJsonArray("arrayWithDefaults").get(0).asJsonObject().getBoolean("booleanExamples") == false);
     }
 
     @Test

--- a/json-schema/src/main/java/io/apptik/json/schema/Schema.java
+++ b/json-schema/src/main/java/io/apptik/json/schema/Schema.java
@@ -274,7 +274,31 @@ public abstract class Schema extends JsonObjectWrapper implements MetaInfo{
     }
 
     public String getDefault() {
-        return getJson().optString("default","");
+        return getJson().optString("default");
+    }
+
+    public Integer getDefaultInt() {
+        return getJson().optInt("default");
+    }
+
+    public Integer getConstInt() {
+        return getJson().optInt("const");
+    }
+
+    public Double getDefaultNumber() {
+        return getJson().optDouble("default");
+    }
+
+    public Double getConstNumber() {
+        return getJson().optDouble("const");
+    }
+
+    public Boolean getDefaultBoolean() {
+        return getJson().optBoolean("default");
+    }
+
+    public Boolean getConstBoolean() {
+        return getJson().optBoolean("const");
     }
 
     public Double getMultipleOf() {
@@ -373,6 +397,14 @@ public abstract class Schema extends JsonObjectWrapper implements MetaInfo{
 
     public JsonObject getDependencies() {
         return getJson().optJsonObject("dependencies");
+    }
+
+    public JsonArray getExamples() {
+        return getJson().optJsonArray("examples");
+    }
+
+    public String getConst() {
+        return getJson().optString("const");
     }
 
     public JsonArray getEnum() {


### PR DESCRIPTION
Hi, I would like to add support for generic default types as listed here: https://json-schema.org/understanding-json-schema/reference/generic.html 
Types are "default", "examples", "const" and "enum". If possible. as am interested in using the convertor, but default types would be useful to us.

Regards

Leo